### PR TITLE
fix(classifier): keep_both when superset is a catch-all (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-21
+
+### Fixed
+
+- **Subset findings against catch-all rules no longer recommend dropping the specific rule.** When a superset rule is a catch-all (umbrella pattern like `generic_secret`), dropping the specific subset (e.g. `terraform_cloud_token`) loses the downstream label and degrades alert quality in DLP/SIEM pipelines. Classifier now auto-detects catch-alls — a rule overlapping with more than `catch_all_threshold` (default 5) other rules, or one explicitly tagged via `metadata["catch_all"] = True` — and flips the recommendation to `keep_both`. Rules can opt out of auto-detection with `metadata["catch_all"] = False`. ([crossfire-rules#9](https://github.com/lumen-argus/crossfire/issues/9))
+
+### Added
+
+- **`OverlapResult.downstream_label_loss: bool`** — true when acting on the recommendation would drop the more specific rule (i.e. `SUBSET`+`keep_a` or `SUPERSET`+`keep_b`). Surfaced in JSON and CSV output so CI gates can filter findings by actual label-loss risk rather than treating all subset pairs equally.
+- **`Classifier(catch_all_threshold=...)`** constructor parameter (default 5).
+
 ## [0.2.1] - 2026-04-10
 
 ### Fixed

--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -1,3 +1,3 @@
 """Crossfire — Regex rule overlap analyzer."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.2"

--- a/crossfire/classifier.py
+++ b/crossfire/classifier.py
@@ -20,6 +20,7 @@ class Classifier:
         threshold: float = 0.8,
         cluster_threshold: float = 0.6,
         overlap_min: float = 0.2,
+        catch_all_threshold: int = 5,
     ) -> None:
         """Initialize classifier.
 
@@ -27,10 +28,15 @@ class Classifier:
             threshold: Minimum overlap to classify as duplicate/subset (0.0-1.0).
             cluster_threshold: Minimum Jaccard similarity for clustering.
             overlap_min: Minimum overlap to report as 'overlap' (below this = disjoint).
+            catch_all_threshold: A superset rule overlapping with more than this many
+                other rules is treated as a catch-all (recommendation becomes
+                KEEP_BOTH to preserve the specific rule's label). Rules with
+                ``metadata["catch_all"] = True`` are always treated as catch-alls.
         """
         self.threshold = threshold
         self.cluster_threshold = cluster_threshold
         self.overlap_min = overlap_min
+        self.catch_all_threshold = catch_all_threshold
 
     def classify(
         self,
@@ -50,6 +56,7 @@ class Classifier:
         """
         rule_map = {r.name: r for r in rules}
         rule_names = [r.name for r in rules]
+        overlap_counts = _compute_overlap_counts(matrix, rule_names)
         results: list[OverlapResult] = []
 
         # Evaluate all unique pairs
@@ -59,7 +66,9 @@ class Classifier:
                 # Skip pairs with zero overlap in both directions
                 if matches_a.get(name_b, 0) == 0 and matrix.get(name_b, {}).get(name_a, 0) == 0:
                     continue
-                result = self._classify_pair(name_a, name_b, matrix, rule_map, corpus_sizes)
+                result = self._classify_pair(
+                    name_a, name_b, matrix, rule_map, corpus_sizes, overlap_counts
+                )
                 if result:
                     results.append(result)
 
@@ -88,6 +97,7 @@ class Classifier:
         matrix: MatchMatrix,
         rule_map: dict[str, Rule],
         corpus_sizes: dict[str, int],
+        overlap_counts: dict[str, int],
     ) -> OverlapResult | None:
         """Classify the relationship between two rules."""
         size_a = corpus_sizes.get(name_a, 0)
@@ -118,7 +128,9 @@ class Classifier:
             overlap_b_to_a,
             rule_map.get(name_a),
             rule_map.get(name_b),
+            overlap_counts,
         )
+        label_loss = _downstream_label_loss(relationship, recommendation)
 
         # Skip disjoint pairs (not worth reporting)
         if relationship == Relationship.DISJOINT:
@@ -168,6 +180,7 @@ class Classifier:
             reason=reason,
             ci_a_to_b=ci_ab,
             ci_b_to_a=ci_ba,
+            downstream_label_loss=label_loss,
         )
 
     def _determine_relationship(
@@ -178,6 +191,7 @@ class Classifier:
         overlap_b_to_a: float,
         rule_a: Rule | None,
         rule_b: Rule | None,
+        overlap_counts: dict[str, int],
     ) -> tuple[Relationship, Recommendation, str]:
         """Determine relationship type, recommendation, and reason."""
         T = self.threshold
@@ -195,6 +209,12 @@ class Classifier:
                     Recommendation.KEEP_BOTH,
                     f"'{name_b}' has higher priority but is a subset",
                 )
+            if self._is_catch_all(name_a, rule_a, overlap_counts):
+                return (
+                    Relationship.SUBSET,
+                    Recommendation.KEEP_BOTH,
+                    f"'{name_a}' is a catch-all — dropping '{name_b}' would lose its label",
+                )
             return (
                 Relationship.SUBSET,
                 Recommendation.KEEP_A,
@@ -210,6 +230,12 @@ class Classifier:
                     Recommendation.KEEP_BOTH,
                     f"'{name_a}' has higher priority but is a subset",
                 )
+            if self._is_catch_all(name_b, rule_b, overlap_counts):
+                return (
+                    Relationship.SUPERSET,
+                    Recommendation.KEEP_BOTH,
+                    f"'{name_b}' is a catch-all — dropping '{name_a}' would lose its label",
+                )
             return (
                 Relationship.SUPERSET,
                 Recommendation.KEEP_B,
@@ -220,6 +246,25 @@ class Classifier:
             return Relationship.OVERLAP, Recommendation.REVIEW, "Partial overlap — review manually"
 
         return Relationship.DISJOINT, Recommendation.KEEP_BOTH, ""
+
+    def _is_catch_all(
+        self,
+        name: str,
+        rule: Rule | None,
+        overlap_counts: dict[str, int],
+    ) -> bool:
+        """True if a rule is a catch-all (broad umbrella pattern).
+
+        A rule is a catch-all if explicitly tagged via ``metadata["catch_all"]``
+        or if it overlaps with more than ``catch_all_threshold`` other rules.
+        """
+        if rule is not None:
+            flag = rule.metadata.get("catch_all")
+            if flag is True:
+                return True
+            if flag is False:
+                return False
+        return overlap_counts.get(name, 0) > self.catch_all_threshold
 
     def _recommend_keep(
         self,
@@ -306,3 +351,36 @@ class Classifier:
             log.info("Built %d clusters from overlapping rules", len(clusters))
 
         return clusters
+
+
+def _compute_overlap_counts(matrix: MatchMatrix, rule_names: list[str]) -> dict[str, int]:
+    """Count how many other rules each rule's pattern matches at least once.
+
+    Used to detect catch-all rules — a rule that overlaps with many others is
+    treated as an umbrella pattern, which flips subset recommendations from
+    "drop the specific rule" to "keep both".
+    """
+    rule_set = set(rule_names)
+    counts: dict[str, int] = dict.fromkeys(rule_names, 0)
+    for rule_name, matches in matrix.items():
+        if rule_name not in rule_set:
+            continue
+        for other_name, count in matches.items():
+            if other_name != rule_name and count > 0 and other_name in rule_set:
+                counts[rule_name] += 1
+    return counts
+
+
+def _downstream_label_loss(
+    relationship: Relationship,
+    recommendation: Recommendation,
+) -> bool:
+    """True if following the recommendation would drop the specific (subset) rule.
+
+    On a SUBSET pair the subset rule is ``rule_b`` (``rule_a`` is the superset),
+    so KEEP_A drops the specific rule. On a SUPERSET pair the subset rule is
+    ``rule_a``, so KEEP_B drops the specific rule.
+    """
+    if relationship == Relationship.SUBSET and recommendation == Recommendation.KEEP_A:
+        return True
+    return relationship == Relationship.SUPERSET and recommendation == Recommendation.KEEP_B

--- a/crossfire/models.py
+++ b/crossfire/models.py
@@ -77,6 +77,7 @@ class OverlapResult:
     reason: str = ""
     ci_a_to_b: tuple[float, float] | None = None  # 95% CI for overlap_a_to_b
     ci_b_to_a: tuple[float, float] | None = None  # 95% CI for overlap_b_to_a
+    downstream_label_loss: bool = False  # True if acting on recommendation drops the specific rule
 
 
 @dataclass

--- a/crossfire/quality.py
+++ b/crossfire/quality.py
@@ -13,6 +13,7 @@ except ImportError:
     import sre_parse  # Python < 3.13
 from dataclasses import dataclass, field
 
+from crossfire.classifier import _compute_overlap_counts
 from crossfire.evaluator import MatchMatrix
 from crossfire.models import CorpusEntry, Rule
 
@@ -73,7 +74,7 @@ def assess_quality(
 
     log.info("Quality assessment started for %d rules", len(rules))
 
-    overlap_counts = _compute_overlap_counts(matrix, rules)
+    overlap_counts = _compute_overlap_counts(matrix, [r.name for r in rules])
     unique_coverage = _compute_unique_coverage(matrix, corpus_sizes, rules)
     random_corpus = _generate_random_strings(specificity_samples, rng)
 
@@ -229,24 +230,6 @@ class _QualityAssessor:
             overlap_count=ovr_count,
             flags=flags,
         )
-
-
-def _compute_overlap_counts(
-    matrix: MatchMatrix,
-    rules: list[Rule],
-) -> dict[str, int]:
-    """Count how many other rules each rule overlaps with."""
-    counts: dict[str, int] = {r.name: 0 for r in rules}
-    rule_names = {r.name for r in rules}
-
-    for rule_name, matches in matrix.items():
-        if rule_name not in rule_names:
-            continue
-        for other_name, count in matches.items():
-            if other_name != rule_name and count > 0 and other_name in rule_names:
-                counts[rule_name] += 1
-
-    return counts
 
 
 def _compute_unique_coverage(

--- a/crossfire/reporter.py
+++ b/crossfire/reporter.py
@@ -159,6 +159,7 @@ def render_csv(report: AnalysisReport, output: TextIO) -> None:
             "relationship",
             "recommendation",
             "reason",
+            "downstream_label_loss",
         ]
     )
 
@@ -176,6 +177,7 @@ def render_csv(report: AnalysisReport, output: TextIO) -> None:
                 r.relationship.value,
                 r.recommendation.value,
                 r.reason,
+                "true" if r.downstream_label_loss else "false",
             ]
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["crossfire*"]
 
 [project]
 name = "crossfire-rules"
-version = "0.2.1"
+version = "0.2.2"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -8,13 +8,19 @@ from crossfire.classifier import Classifier
 from crossfire.models import Recommendation, Relationship, Rule
 
 
-def _make_rule(name: str, source: str = "test", priority: int = 0) -> Rule:
+def _make_rule(
+    name: str,
+    source: str = "test",
+    priority: int = 0,
+    metadata: dict[str, object] | None = None,
+) -> Rule:
     return Rule(
         name=name,
         pattern=".",
         compiled=re.compile("."),
         source=source,
         priority=priority,
+        metadata=metadata or {},
     )
 
 
@@ -247,6 +253,172 @@ class TestRecommendation:
         subs = [r for r in results if r.relationship == Relationship.SUBSET]
         assert len(subs) == 1
         assert subs[0].recommendation == Recommendation.KEEP_A  # broad is the superset
+
+
+class TestCatchAllSuperset:
+    """Catch-all superset rules should not trigger 'drop the specific rule'.
+
+    Regression for issue #9: terraform_cloud_token ⊂ generic_secret. Dropping the
+    specific rule would lose the downstream label; both should be kept.
+    """
+
+    def _catch_all_matrix(self) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
+        # 'generic' is a catch-all: matches all of s1..s6's corpora (6 other rules
+        # > default catch_all_threshold=5), but each specific rule only matches
+        # its own corpus.
+        specifics = [f"s{i}" for i in range(1, 7)]
+        matrix: dict[str, dict[str, int]] = {"generic": {"generic": 50}}
+        for s in specifics:
+            matrix["generic"][s] = 48
+            matrix[s] = {"generic": 5, s: 50}
+        sizes = {"generic": 50, **dict.fromkeys(specifics, 50)}
+        return matrix, sizes
+
+    def test_auto_detected_catch_all_keeps_both(self):
+        """Superset that overlaps with many rules → KEEP_BOTH, no label loss."""
+        classifier = Classifier(threshold=0.8)
+        rules = [_make_rule("generic")] + [_make_rule(f"s{i}") for i in range(1, 7)]
+        matrix, sizes = self._catch_all_matrix()
+
+        results, _ = classifier.classify(matrix, rules, sizes)
+        subsets = [r for r in results if r.relationship == Relationship.SUBSET]
+        assert subsets, "expected subset findings against the catch-all"
+        for r in subsets:
+            assert r.rule_a == "generic"
+            assert r.recommendation == Recommendation.KEEP_BOTH
+            assert "catch-all" in r.reason
+            assert r.downstream_label_loss is False
+
+    def test_explicit_metadata_flag_keeps_both(self):
+        """metadata.catch_all=True forces KEEP_BOTH even with few overlaps."""
+        classifier = Classifier(threshold=0.8)
+        rules = [
+            _make_rule("generic", metadata={"catch_all": True}),
+            _make_rule("specific"),
+        ]
+        matrix = {
+            "generic": {"generic": 50, "specific": 48},
+            "specific": {"generic": 10, "specific": 50},
+        }
+        sizes = {"generic": 50, "specific": 50}
+
+        results, _ = classifier.classify(matrix, rules, sizes)
+        subsets = [r for r in results if r.relationship == Relationship.SUBSET]
+        assert len(subsets) == 1
+        assert subsets[0].recommendation == Recommendation.KEEP_BOTH
+        assert "catch-all" in subsets[0].reason
+        assert subsets[0].downstream_label_loss is False
+
+    def test_explicit_false_disables_auto_detection(self):
+        """metadata.catch_all=False suppresses auto-detection (opt-out)."""
+        classifier = Classifier(threshold=0.8)
+        # Same matrix as auto-detection case, but the catch-all rule opts out.
+        specifics = [f"s{i}" for i in range(1, 7)]
+        rules = [_make_rule("generic", metadata={"catch_all": False})] + [
+            _make_rule(s) for s in specifics
+        ]
+        matrix, sizes = self._catch_all_matrix()
+
+        results, _ = classifier.classify(matrix, rules, sizes)
+        subsets = [r for r in results if r.relationship == Relationship.SUBSET]
+        assert subsets
+        for r in subsets:
+            assert r.recommendation == Recommendation.KEEP_A
+            assert r.downstream_label_loss is True
+
+    def test_superset_relationship_also_handled(self):
+        """Catch-all on the B side of a SUPERSET pair also keeps both."""
+        classifier = Classifier(threshold=0.8)
+        # 'specific' is rule_a, 'generic' is rule_b → SUPERSET.
+        rules = [
+            _make_rule("specific"),
+            _make_rule("generic", metadata={"catch_all": True}),
+        ]
+        matrix = {
+            "specific": {"specific": 50, "generic": 10},
+            "generic": {"specific": 48, "generic": 50},
+        }
+        sizes = {"specific": 50, "generic": 50}
+
+        results, _ = classifier.classify(matrix, rules, sizes)
+        sups = [r for r in results if r.relationship == Relationship.SUPERSET]
+        assert len(sups) == 1
+        assert sups[0].recommendation == Recommendation.KEEP_BOTH
+        assert sups[0].downstream_label_loss is False
+
+    def test_superset_explicit_false_disables_auto_detection(self):
+        """metadata.catch_all=False on the B side of a SUPERSET pair opts out too."""
+        classifier = Classifier(threshold=0.8)
+        # 'generic' has enough overlaps to auto-trigger, but opts out via metadata.
+        # Put it second so it lands on the B side of a SUPERSET pair.
+        specifics = [f"s{i}" for i in range(1, 7)]
+        rules = (
+            [_make_rule(specifics[0])]
+            + [_make_rule("generic", metadata={"catch_all": False})]
+            + [_make_rule(s) for s in specifics[1:]]
+        )
+        matrix: dict[str, dict[str, int]] = {"generic": {"generic": 50}}
+        for s in specifics:
+            matrix["generic"][s] = 48
+            matrix[s] = {"generic": 5, s: 50}
+        sizes = {"generic": 50, **dict.fromkeys(specifics, 50)}
+
+        results, _ = classifier.classify(matrix, rules, sizes)
+        # The (s1, generic) pair is SUPERSET (generic is broader, rule_b).
+        pair = next(r for r in results if {r.rule_a, r.rule_b} == {"s1", "generic"})
+        assert pair.relationship == Relationship.SUPERSET
+        assert pair.recommendation == Recommendation.KEEP_B
+        assert pair.downstream_label_loss is True
+
+
+class TestDownstreamLabelLoss:
+    """Verify label-loss flag on all recommendation paths."""
+
+    def test_subset_keep_a_loses_label(self):
+        classifier = Classifier(threshold=0.8)
+        rules = [_make_rule("broad"), _make_rule("specific")]
+        matrix = {
+            "broad": {"broad": 50, "specific": 48},
+            "specific": {"broad": 10, "specific": 50},
+        }
+        sizes = {"broad": 50, "specific": 50}
+        results, _ = classifier.classify(matrix, rules, sizes)
+        assert results[0].relationship == Relationship.SUBSET
+        assert results[0].recommendation == Recommendation.KEEP_A
+        assert results[0].downstream_label_loss is True
+
+    def test_subset_keep_both_preserves_label(self):
+        """Priority override on subset → KEEP_BOTH → no label loss."""
+        classifier = Classifier(threshold=0.8)
+        rules = [_make_rule("broad", priority=1), _make_rule("specific", priority=10)]
+        matrix = {
+            "broad": {"broad": 50, "specific": 48},
+            "specific": {"broad": 10, "specific": 50},
+        }
+        sizes = {"broad": 50, "specific": 50}
+        results, _ = classifier.classify(matrix, rules, sizes)
+        assert results[0].recommendation == Recommendation.KEEP_BOTH
+        assert results[0].downstream_label_loss is False
+
+    def test_duplicate_does_not_flag_label_loss(self):
+        """Duplicates aren't a specific-vs-general tradeoff — no label loss flag."""
+        classifier = Classifier(threshold=0.8)
+        rules = [_make_rule("a", priority=10), _make_rule("b", priority=5)]
+        matrix = {"a": {"a": 50, "b": 45}, "b": {"a": 42, "b": 50}}
+        sizes = {"a": 50, "b": 50}
+        results, _ = classifier.classify(matrix, rules, sizes)
+        assert results[0].relationship == Relationship.DUPLICATE
+        assert results[0].recommendation == Recommendation.KEEP_A
+        assert results[0].downstream_label_loss is False
+
+    def test_overlap_does_not_flag_label_loss(self):
+        classifier = Classifier(threshold=0.8, overlap_min=0.2)
+        rules = [_make_rule("a"), _make_rule("b")]
+        matrix = {"a": {"a": 50, "b": 20}, "b": {"a": 15, "b": 50}}
+        sizes = {"a": 50, "b": 50}
+        results, _ = classifier.classify(matrix, rules, sizes)
+        assert results[0].relationship == Relationship.OVERLAP
+        assert results[0].downstream_label_loss is False
 
 
 class TestEmptyInputs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+import crossfire
 from crossfire.cli import main
 
 
@@ -204,7 +205,7 @@ class TestGlobalOptions:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert crossfire.__version__ in result.output
 
     def test_log_level(self, sample_rules_path: str):
         runner = CliRunner()

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import re
 
+from crossfire.classifier import _compute_overlap_counts
 from crossfire.models import CorpusEntry, Rule
 from crossfire.quality import (
     QualityReport,
-    _compute_overlap_counts,
     _compute_unique_coverage,
     _pattern_complexity,
     assess_quality,
@@ -41,14 +41,14 @@ class TestOverlapCounts:
     def test_no_overlaps(self):
         rules = [_make_rule("a", "x"), _make_rule("b", "y")]
         matrix = {"a": {"a": 10}, "b": {"b": 10}}
-        counts = _compute_overlap_counts(matrix, rules)
+        counts = _compute_overlap_counts(matrix, [r.name for r in rules])
         assert counts["a"] == 0
         assert counts["b"] == 0
 
     def test_mutual_overlap(self):
         rules = [_make_rule("a", "x"), _make_rule("b", "y")]
         matrix = {"a": {"a": 10, "b": 5}, "b": {"a": 5, "b": 10}}
-        counts = _compute_overlap_counts(matrix, rules)
+        counts = _compute_overlap_counts(matrix, [r.name for r in rules])
         assert counts["a"] == 1
         assert counts["b"] == 1
 
@@ -65,7 +65,7 @@ class TestOverlapCounts:
             "b": {"b": 10},
             "c": {"c": 10},
         }
-        counts = _compute_overlap_counts(matrix, rules)
+        counts = _compute_overlap_counts(matrix, [r.name for r in rules])
         assert counts["broad"] == 3
 
 


### PR DESCRIPTION
## Summary

Fixes #9. Subset findings against catch-all rules (e.g. `terraform_cloud_token ⊂ generic_secret`) previously recommended dropping the specific rule, which silently degrades downstream label specificity in DLP/SIEM pipelines. This PR auto-detects catch-alls and recommends `keep_both` instead, plus exposes a `downstream_label_loss` field so CI gates can filter findings by actual tradeoff.

## Changes

- `classifier.py`: auto-detect catch-all via overlap count (>5 other rules, configurable via `Classifier(catch_all_threshold=...)`) OR explicit `rule.metadata["catch_all"]`. `True` forces catch-all, `False` forces opt-out. Subset/superset recommendation flips to `keep_both` when the superset side is a catch-all.
- `models.py`: new `OverlapResult.downstream_label_loss: bool` (default False). True only when recommendation would drop the specific rule.
- `reporter.py`: new `downstream_label_loss` column in CSV. JSON output includes it automatically via `asdict`.
- `quality.py`: `_compute_overlap_counts` moved to `classifier.py` to dedupe; `quality.py` now imports it.
- Version bumped 0.2.1 → 0.2.2 in both `pyproject.toml` and `crossfire/__init__.py` (they were drifting — 0.2.1 and 0.1.0 respectively; now matched).
- CLI `test_version` now reads `crossfire.__version__` instead of hardcoding.
- New tests: `TestCatchAllSuperset` (auto-detection, explicit `True`/`False` on both SUBSET and SUPERSET sides) and `TestDownstreamLabelLoss` (flag across all recommendation paths including duplicates and overlaps).

## Test plan

- [x] Tests pass (`pytest` — 246 passed)
- [x] Lint passes (`ruff check crossfire/ tests/`)
- [x] Type check passes (`mypy crossfire/`)
- [x] End-to-end repro of issue #9 scenario confirmed: catch-all detected, recommendation is `keep_both` with clear reason, `downstream_label_loss=False`

## Breaking changes

**Behavior change, no API break:** subset findings where the superset overlaps with >5 other rules now recommend `keep_both` rather than dropping the subset. Users who want the old behavior can set `catch_all_threshold` to a very large number on the `Classifier` constructor, or tag the rule with `metadata["catch_all"] = False`. The `OverlapResult` dataclass gained a new optional field with a default, so existing code consuming results still works.