### PR TITLE
Release 0.2.3: stdlib-first regex validation for --skip-invalid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2026-04-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Minimum Python bumped to 3.12** (was 3.11). CI now tests 3.12 and 3.13.
+
+### Fixed
+
+- **`--skip-invalid` now catches stdlib-incompatible patterns at load time, in one place.** The loader compiles via `crossfire.regex` (RE2 when available), which historically accepted patterns that Python's `re` rejects — notably non-leading global flags like `(?i)` mid-pattern in some gitleaks TOMLs. Because `ProcessPoolExecutor` workers recompile patterns with stdlib `re` by design (importing the `crossfire` package in workers adds ~20ms each under spawn), such a rule would load fine, then abort the whole worker pool later with `re.PatternError` — regardless of `--skip-invalid`. `crossfire.regex.compile` now validates every pattern against stdlib `re` before returning the RE2-compiled form, so asymmetric patterns are rejected at load time with the loader's standard `ValidationError` (fail-fast, or WARNING + skip under `--skip-invalid`). Downstream stages (generator, evaluator) can assume stdlib-compatibility for every rule they receive. The per-worker `re.error` handler in `_generate_for_rule_worker` remains as defense-in-depth for library callers who construct `Rule` objects without going through the loader.
+
+### Known issue
+
+- When `google-re2` is installed, a handful of CLI/plugin tests (`test_scan_overlapping`, `test_scan_table_format`, `test_fail_on_duplicate`, `test_output_to_file`, `test_scan_gitleaks_rules`) can fail with "only N valid samples" on broad `\s*`/`\S+` patterns. This is a separate bug: the generator uses `rstr` (stdlib-sre grammar) to synthesize strings but validates them against the loader's RE2-compiled pattern, and RE2's `\s`/`\S` semantics diverge enough from stdlib that most generated strings are rejected. The fix is generator-local (validate with a stdlib-compiled copy during generation, or swap the sampler) and unrelated to the load-time asymmetry above.
+
 ## [0.2.2] - 2026-04-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ crossfire diff rules.json --corpus-a a.jsonl --corpus-b b.jsonl  # Coverage drif
 
 ## CI Integration
 
-- `.github/workflows/test.yml` — pytest + ruff on push/PR (Python 3.11-3.13)
+- `.github/workflows/test.yml` — pytest + ruff on push/PR (Python 3.12-3.13)
 - `.github/workflows/release.yml` — PyPI publish on tag (trusted publishing)
 - `action.yml` — GitHub Action for users to run crossfire in their CI
 - `.pre-commit-hooks.yaml` — pre-commit hooks (crossfire-scan, crossfire-validate)

--- a/crossfire/cli.py
+++ b/crossfire/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 
 import click
 
@@ -14,8 +14,6 @@ from crossfire.corpus import DiffReport, EvaluationReport
 from crossfire.errors import CrossfireError, LoadError, ValidationError
 from crossfire.logging import setup_logging
 
-F = TypeVar("F", bound=Callable[..., Any])
-
 # Exit codes
 EXIT_OK = 0
 EXIT_DUPLICATES = 1
@@ -23,7 +21,7 @@ EXIT_INPUT_ERROR = 2
 EXIT_RUNTIME_ERROR = 3
 
 
-def _logging_options(f: F) -> F:
+def _logging_options[F: Callable[..., Any]](f: F) -> F:
     """Shared logging options for all commands."""
     f = click.option(
         "--log-format", default="text", type=click.Choice(["text", "json"]), help="Log format."

--- a/crossfire/generator.py
+++ b/crossfire/generator.py
@@ -71,7 +71,22 @@ def _generate_for_rule_worker(
     if rule_seed is not None:
         random.seed(rule_seed)
 
-    compiled = re.compile(rule_pattern)
+    # Defense-in-depth: the loader's `crossfire.regex.compile` already rejects
+    # any pattern stdlib `re` cannot compile, so this branch should be
+    # unreachable when the Rule came from `load_rules`. It still matters for
+    # library callers who construct Rule objects directly and feed them to
+    # CorpusGenerator, bypassing the loader — without this guard their rogue
+    # pattern would crash the worker pool and defeat skip_invalid.
+    try:
+        compiled = re.compile(rule_pattern)
+    except re.error as exc:
+        raise GenerationError(
+            f"Rule '{rule_name}': pattern is not compilable by the stdlib re "
+            f"module ({exc}). The loader normally catches this; if you built "
+            f"this Rule directly, run `crossfire.regex.compile` on the pattern "
+            f"first so load-time validation still applies.",
+            rule_name=rule_name,
+        ) from exc
 
     gen = CorpusGenerator(
         samples_per_rule=samples_per_rule,

--- a/crossfire/loader.py
+++ b/crossfire/loader.py
@@ -226,7 +226,10 @@ def load_rules(
             skipped += 1
             continue
 
-        # Compile regex (uses RE2 when available for faster matching)
+        # Compile regex. `cre.compile` always validates with stdlib `re` so
+        # downstream workers (which recompile with stdlib) can assume the
+        # pattern is stdlib-safe; RE2 is returned on top of that for faster
+        # matching when available.
         try:
             compiled = cre.compile(pattern)
         except re.error as e:

--- a/crossfire/regex.py
+++ b/crossfire/regex.py
@@ -1,8 +1,12 @@
 """Regex compilation with optional RE2 acceleration.
 
-Tries google-re2 first (10-100x faster for compatible patterns),
-falls back to Python's re module for patterns using backreferences,
-lookahead, or other PCRE-only features.
+Every pattern is validated against Python's stdlib `re` — that's the lowest
+common denominator, since `ProcessPoolExecutor` workers recompile from
+pattern strings with stdlib `re` by design. When the pattern is stdlib-valid
+and google-re2 is installed, the RE2-compiled form is returned for faster
+matching (10-100x for compatible patterns); otherwise the stdlib form is
+returned. RE2 cannot handle backreferences, lookahead/lookbehind, or other
+PCRE-only features — those patterns fall through to stdlib.
 
 Install RE2 support: pip install crossfire-rules[re2]
 """
@@ -32,18 +36,39 @@ def is_re2_available() -> bool:
 def compile(pattern: str) -> CompiledPattern:
     """Compile a regex pattern, using RE2 when available and compatible.
 
+    Patterns are *always* validated against stdlib `re` as well, even when RE2
+    succeeds. This is the single place that enforces the loader's contract to
+    downstream workers: `ProcessPoolExecutor` workers (generator, evaluator on
+    macOS/Windows) recompile patterns with stdlib `re` by design — importing
+    the `crossfire` package in workers adds ~20ms each under spawn — so any
+    pattern the loader accepts must be stdlib-compilable. RE2 has a strictly
+    different grammar (e.g. it accepts non-leading `(?i)` flags that stdlib
+    `re` rejects on Python 3.11+), and letting such a pattern through the
+    loader would abort the whole worker pool later regardless of
+    `--skip-invalid`.
+
     Args:
         pattern: Regex pattern string.
 
     Returns:
-        Compiled pattern object (re2.Pattern or re.Pattern).
+        Compiled pattern object (re2.Pattern or re.Pattern). RE2 is returned
+        when available and it accepts the pattern; otherwise the stdlib
+        compiled form is returned.
 
     Raises:
-        re.error: If the pattern is invalid in both RE2 and re.
+        re.error: If stdlib `re` cannot compile the pattern. Callers (today,
+            only the loader) translate this into `ValidationError` and honor
+            `--skip-invalid`.
     """
+    # Validate stdlib first so the caller sees a stdlib `re.error` for bad
+    # patterns even when RE2 would have accepted them. We hang on to the
+    # compiled form so the RE2-unavailable / RE2-rejects path doesn't
+    # redundantly compile again.
+    stdlib_compiled = re.compile(pattern)
+
     if _RE2_AVAILABLE:
         try:
             return re2.compile(pattern)  # type: ignore[no-any-return]
         except Exception:
             log.debug("RE2 cannot compile pattern (falling back to re): %r", pattern)
-    return re.compile(pattern)
+    return stdlib_compiled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.2"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [
     {name = "Crossfire Contributors"}
 ]
@@ -20,7 +20,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Security",
@@ -58,7 +57,7 @@ Homepage = "https://github.com/lumen-argus/crossfire"
 Repository = "https://github.com/lumen-argus/crossfire"
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
@@ -88,7 +87,7 @@ ignore = [
 known-first-party = ["crossfire"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["crossfire*"]
 
 [project]
 name = "crossfire-rules"
-version = "0.2.2"
+version = "0.2.3"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -488,6 +488,78 @@ class TestParallelTimeouts:
             gen._generate_parallel(rules, skip_invalid=False)
 
 
+class TestWorkerCompileFailure:
+    """The worker re-compiles patterns with stdlib `re`. If the loader accepted
+    a pattern via RE2 that stdlib can't compile (e.g. non-leading `(?i)`), the
+    worker must surface that as a per-rule GenerationError so `--skip-invalid`
+    can honor its promise — not crash the whole batch with `re.PatternError`.
+    """
+
+    @staticmethod
+    def _bad_pattern_rule() -> Rule:
+        # This test targets the worker's defense-in-depth branch: the loader
+        # now rejects non-leading global flags at load time, so in normal use a
+        # pattern like `(?i)foo(?i)bar` never reaches a worker. We bypass
+        # `crossfire.regex.compile` (and therefore the loader's stdlib-first
+        # validation) by stuffing a MagicMock into `compiled`, so only
+        # `rule.pattern` — the string that the worker re-compiles with stdlib
+        # `re` — carries the bad flag. That mirrors the one scenario the
+        # defense-in-depth guard is there for: library callers who construct
+        # `Rule` objects directly and skip `load_rules`. Test is stable whether
+        # or not `google-re2` is installed.
+        from unittest.mock import MagicMock
+
+        return Rule(name="bad_flag", pattern=r"(?i)foo(?i)bar", compiled=MagicMock())
+
+    def test_worker_translates_re_error_to_generation_error(self):
+        """Unit test for the worker itself — no subprocesses."""
+        from crossfire.generator import _generate_for_rule_worker
+
+        with pytest.raises(GenerationError, match="not compilable by the stdlib re"):
+            _generate_for_rule_worker(
+                rule_name="bad_flag",
+                rule_pattern=r"(?i)foo(?i)bar",
+                samples_per_rule=10,
+                negative_samples=0,
+                max_string_length=256,
+                generation_timeout_s=1.0,
+                min_valid_samples=5,
+                rule_seed=42,
+            )
+
+    def test_parallel_skip_invalid_survives_stdlib_incompatible_pattern(self):
+        """End-to-end: a bad pattern in a parallel batch should be skipped, not crash."""
+        gen = CorpusGenerator(
+            samples_per_rule=15,
+            min_valid_samples=5,
+            negative_samples=0,
+            generation_timeout_s=0.5,
+            seed=42,
+            parallel=True,
+        )
+        rules = [_make_rule(f"ok_{i}", rf"[a-z]{{{i + 3}}}") for i in range(8)]
+        rules.append(self._bad_pattern_rule())
+        entries = gen.generate(rules, skip_invalid=True)
+        sources = {e.source_rule for e in entries}
+        assert "bad_flag" not in sources
+        assert sources == {f"ok_{i}" for i in range(8)}
+
+    def test_parallel_raises_clean_error_without_skip_invalid(self):
+        """Without skip_invalid, the failure surfaces as GenerationError — not raw re.error."""
+        gen = CorpusGenerator(
+            samples_per_rule=15,
+            min_valid_samples=5,
+            negative_samples=0,
+            generation_timeout_s=0.5,
+            seed=42,
+            parallel=True,
+        )
+        rules = [_make_rule(f"ok_{i}", rf"[a-z]{{{i + 3}}}") for i in range(8)]
+        rules.append(self._bad_pattern_rule())
+        with pytest.raises(GenerationError, match="not compilable by the stdlib re"):
+            gen.generate(rules, skip_invalid=False)
+
+
 class TestSpawnContext:
     """Verify that the default mp_context is the safe one."""
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -80,6 +80,56 @@ class TestFailFastValidation:
         assert len(rules) == 1
         assert rules[0].name == "valid"
 
+    def test_stdlib_incompatible_pattern_fails(self, tmp_path: Path):
+        # Non-leading `(?i)` flags: stdlib `re` rejects on 3.11+. Without RE2
+        # the stdlib fallback already caught this; the regression that
+        # prompted the fix was that when RE2 is installed, the loader used
+        # to accept the pattern and the parallel worker then crashed on
+        # stdlib `re.compile`. The companion test below covers that config.
+        data = [{"name": "non_leading_flag", "pattern": r"(?i)foo(?i)bar"}]
+        path = tmp_path / "rules.json"
+        path.write_text(json.dumps(data))
+        with pytest.raises(ValidationError, match="invalid regex"):
+            load_rules(str(path))
+
+    def test_stdlib_incompatible_pattern_with_skip(self, tmp_path: Path):
+        data = [
+            {"name": "non_leading_flag", "pattern": r"(?i)foo(?i)bar"},
+            {"name": "valid", "pattern": "[a-z]+"},
+        ]
+        path = tmp_path / "rules.json"
+        path.write_text(json.dumps(data))
+        rules = load_rules(str(path), skip_invalid=True)
+        assert [r.name for r in rules] == ["valid"]
+
+    @pytest.mark.skipif(
+        not __import__("crossfire.regex", fromlist=["is_re2_available"]).is_re2_available(),
+        reason="RE2 asymmetry is only observable when google-re2 is installed",
+    )
+    def test_re2_accepted_but_stdlib_rejected_fails_load(self, tmp_path: Path):
+        """Regression guard for the original 0.2.2 bug: when google-re2 is
+        installed, the loader must still reject patterns that RE2 accepts but
+        stdlib `re` cannot compile. Without this test, a revert of the
+        stdlib-first validation in `crossfire.regex.compile` would pass the
+        default (no-RE2) test suite.
+        """
+        import re2
+
+        pattern = r"(?i)foo(?i)bar"
+        try:
+            re2.compile(pattern)
+        except Exception as exc:
+            pytest.skip(
+                f"RE2 no longer accepts {pattern!r} ({exc}); regression guard is "
+                f"vacuous — pick a new RE2-accepted / stdlib-rejected pattern."
+            )
+
+        data = [{"name": "re2_only", "pattern": pattern}]
+        path = tmp_path / "rules.json"
+        path.write_text(json.dumps(data))
+        with pytest.raises(ValidationError, match="invalid regex"):
+            load_rules(str(path))
+
     def test_empty_pattern_fails(self, tmp_path: Path):
         data = [{"name": "empty", "pattern": ""}]
         path = tmp_path / "rules.json"


### PR DESCRIPTION
## Summary

Fixes an architectural asymmetry where `crossfire 0.2.2`'s `compare --skip-invalid` crashed `ProcessPoolExecutor` workers with `re.PatternError` despite the skip flag. Moves stdlib-compile validation into `crossfire.regex.compile` so the loader enforces the lowest-common-denominator contract in one place, and the existing `re.error → ValidationError → --skip-invalid` path handles it correctly.

## Changes

- **`crossfire/regex.py`**: `compile()` now validates every pattern against stdlib `re` *before* returning an RE2-compiled form. Previously, RE2 would accept patterns stdlib rejects (notably non-leading `(?i)` flags on Python 3.11+, common in gitleaks TOMLs), causing workers that recompile with stdlib `re` to abort the whole pool.
- **`crossfire/generator.py`**: Worker keeps a `re.error → GenerationError` translator as defense-in-depth for library callers who construct `Rule` objects without going through `load_rules`.
- **`crossfire/loader.py`**: Comment updated to describe the new stdlib-first contract.
- **Python minimum bumped to 3.12** (was 3.11). Consistent with precedent (0.2.1 bumped 3.10→3.11 the same way). CI matrix now covers 3.12 and 3.13.
- **`crossfire/cli.py`**: `_logging_options` migrated to PEP 695 generic syntax.
- **Tests**: load-time tests for stdlib-incompatible patterns, an RE2-gated regression guard that skips cleanly when `google-re2` isn't installed, and worker-side unit tests for the defense-in-depth path.
- **CHANGELOG "Known issue"**: discloses a separate, pre-existing RE2 `\s`/`\S` semantic-drift issue affecting 5 CLI tests when RE2 is installed — unrelated to this fix.

## Test plan

- [x] Tests pass (`pytest`) — 247/251 with RE2, 251/251 without (4 pre-existing `\s`/`\S` drift failures documented as known issue)
- [x] Lint passes (`ruff check crossfire/ tests/`)
- [x] Type check passes (`mypy crossfire/`)
- [x] Pre-commit hooks green

## Breaking changes

- **Minimum Python bumped to 3.12**. Users on 3.11 will need to upgrade.
- Patterns that RE2 accepts but stdlib rejects (e.g. non-leading `(?i)` flags) are now rejected at load time. Previously, such patterns would load, then abort the parallel worker pool at runtime. Users relying on the former behavior (sequential-only paths on RE2-installed systems) should use `--skip-invalid` or fix the pattern.