### PR TITLE
Release 0.2.4: resolve __version__ from distribution metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-04-21
+
+### Fixed
+
+- **`crossfire.__version__` and `crossfire --version` now report the real installed version.** In 0.2.3 the distribution metadata was `0.2.3` but `crossfire/__init__.py` still hardcoded `__version__ = "0.2.2"`, so `crossfire --version` and the `AnalysisReport.crossfire_version` field reported the stale string. Source: `crossfire/__init__.py` now resolves `__version__` via `importlib.metadata.version("crossfire-rules")`, making `pyproject.toml` the single source of truth and eliminating this class of drift. Added a regression test (`tests/test_version.py`) asserting `__version__` equals the distribution metadata at runtime. Cosmetic in 0.2.3 — no functional behavior changed.
+
 ## [0.2.3] - 2026-04-21
 
 ### Changed

--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -1,3 +1,15 @@
 """Crossfire — Regex rule overlap analyzer."""
 
-__version__ = "0.2.2"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("crossfire-rules")
+except PackageNotFoundError:
+    # Running from a source tree without the distribution installed
+    # (e.g. `python -m crossfire` from a fresh clone). Uninstalled state is
+    # not a supported deploy target, but we keep a well-known sentinel so
+    # `crossfire --version` doesn't crash during that workflow.
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["crossfire*"]
 
 [project]
 name = "crossfire-rules"
-version = "0.2.3"
+version = "0.2.4"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,32 @@
+"""Guard: `crossfire.__version__` must agree with the installed distribution.
+
+Previously (<= 0.2.3), `__version__` was a hardcoded string in
+`crossfire/__init__.py`. It drifted from `pyproject.toml` on the 0.2.3 release
+— the wheel shipped as 0.2.3 but `crossfire --version` printed 0.2.2. This
+test pins the contract that `pyproject.toml` is the single source of truth.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import version as pkg_version
+
+import crossfire
+
+
+def test_version_matches_distribution_metadata() -> None:
+    assert crossfire.__version__ == pkg_version("crossfire-rules"), (
+        "__version__ drift detected. Do not hardcode the version in "
+        "crossfire/__init__.py — bump pyproject.toml instead."
+    )
+
+
+def test_version_is_a_real_semver_not_the_uninstalled_sentinel() -> None:
+    # `0.0.0+unknown` is the sentinel returned when the package isn't
+    # installed (pure source tree). CI always installs via `pip install -e .`,
+    # so the sentinel showing up here would mean the package's entry in
+    # site-packages is broken.
+    assert crossfire.__version__ != "0.0.0+unknown"
+    assert re.match(r"^\d+\.\d+\.\d+", crossfire.__version__), (
+        f"Expected semver; got {crossfire.__version__!r}"
+    )


### PR DESCRIPTION
## Summary

Industrial-standard fix for a cosmetic version-drift bug reported against 0.2.3: the wheel shipped as `0.2.3` but `crossfire/__init__.py` still hardcoded `__version__ = "0.2.2"`, so `crossfire --version` and `AnalysisReport.crossfire_version` printed the stale string.

Root cause: two sources of truth (`pyproject.toml` + a hardcoded `__version__`). Fix: collapse to one — resolve `__version__` from `importlib.metadata.version("crossfire-rules")` at import time. This is the standard approach recommended by PyPA and used by most modern packages.

## Changes

- **`crossfire/__init__.py`** — `__version__` is now `importlib.metadata.version("crossfire-rules")`, with a `PackageNotFoundError → "0.0.0+unknown"` fallback for running from an un-pip-installed source tree. `importlib.metadata` is stdlib (3.8+); we require 3.12+.
- **`tests/test_version.py` (new)** — asserts `crossfire.__version__` matches the installed distribution metadata, and guards against the uninstalled sentinel leaking into production.
- **`pyproject.toml`** — bumped to `0.2.4`.
- **`CHANGELOG.md`** — new `[0.2.4]` section documenting the fix.

## Test plan

- [x] `tests/test_version.py` passes
- [x] `crossfire --version` prints `0.2.4` after `pip install -e .`
- [x] `python -c "import crossfire; print(crossfire.__version__)"` → `0.2.4`
- [x] `ruff check`, `ruff format --check`, `mypy crossfire/` all clean
- [x] Existing test suite unaffected (5 pre-existing RE2 `\s`/`\S` drift failures unchanged — disclosed in 0.2.3 "Known issue")

## Breaking changes

None. `crossfire.__version__` remains a string at module level; only the source of its value changes.

## Release note

After merge: tag `v0.2.4` and push to trigger the PyPI release workflow.