### PR TITLE
Release 0.2.6: mutational corpus augmentation + keep trying on rstr exceptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
       - id: detect-private-key
+        # Test fixtures and CHANGELOG reference PEM key-header markers as
+        # example patterns (e.g. gitleaks rules that match leaked keys) —
+        # they're fixture/doc content, not real keys. Scope the exclude
+        # narrowly; every other file still gets scanned.
+        exclude: ^(CHANGELOG\.md|tests/test_generator\.py)$
       - id: check-added-large-files
         args: ['--maxkb=500']
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-04-21
+
+### Added
+
+- **Mutational corpus augmentation** (pipeline stage 2). After `rstr.xeger` produces the minimal matches for a pattern, each base match is padded with random prefix/suffix context and re-validated. This is the standard mutational-fuzzing move (AFL/libFuzzer style) and mirrors how real corpora look — the matched substring embedded in surrounding text — so literal-heavy but unanchored rules now produce the full `samples_per_rule` instead of 1-5. Rules like `-----BEGIN OPENSSH PRIVATE KEY-----`, `-----BEGIN (?:RSA|EC|DSA|OPENSSH)?PRIVATE KEY-----`, and `(?i)\[INST\]` go from 1-5 samples to 30 samples at default settings. Fully-anchored narrow patterns (`^literal$`) remain at their intrinsic minimum — padding breaks the anchor so re-validation rejects the candidates, as expected.
+
+### Fixed
+
+- **`rstr.xeger` exceptions no longer abort sampling.** The rstr loop used to `break` on the first exception; some gitleaks-style patterns raise intermittently (~40-50% of calls) but would otherwise produce plenty of valid output. The loop now continues through exceptions, so patterns like `atlassian_api_token` that previously generated zero samples (first call threw, loop exited) now generate the full `samples_per_rule`.
+- **Narrow-match-language rules no longer false-fail `min_valid_samples`.** Combined with mutational augmentation above, rules whose regex has an inherently small match set now reach the sample target through padding instead of tripping the hard failure path. Downstream impact for `lumen-argus/community.json` (90-rule set): 4 of the 6 previously-regressing rules now generate cleanly (`ssh_private_key`, `private_key_pem`, `inst_tag`, `atlassian_api_token`). The remaining 2 remain skipped under `skip_invalid=True` because the current rstr + padding + random-ASCII pipeline can't synthesize them: `cloudflare_origin_ca_key` has a `{146}` fixed-repetition clause that trips rstr's internal sampler (`randint(146, 100)` → `ValueError`), and `kubernetes_secret_yaml` combines `(?s:.){0,200}?` wildcards with literal anchors that random padding can't satisfy. A sampler that handles large fixed-count repetitions (or a structured YAML-aware generator) would recover them; out of scope for this release.
+
 ## [0.2.5] - 2026-04-21
 
 ### Fixed

--- a/crossfire/generator.py
+++ b/crossfire/generator.py
@@ -104,9 +104,27 @@ def _generate_for_rule_worker(
 class CorpusGenerator:
     """Generates synthetic test strings from regex patterns.
 
-    Uses rstr as the primary generator with a manual fallback for patterns
-    that rstr cannot handle. All generated strings are validated against
-    the source rule's compiled regex before inclusion.
+    Pipeline (each stage runs only when the previous didn't reach
+    `samples_per_rule`):
+
+    1. `rstr.xeger` produces minimal matches from the pattern's AST — fast
+       and precise when the pattern has inherent variability.
+    2. Mutational augmentation pads every base match with random context
+       and re-validates, AFL/libFuzzer style. This is what fills the corpus
+       for literal-heavy but unanchored rules (e.g. `-----BEGIN OPENSSH
+       PRIVATE KEY-----`) to the full `samples_per_rule`.
+    3. Random-ASCII fallback as a last resort for patterns rstr can't parse
+       at all; only productive on patterns broad enough that random strings
+       happen to match.
+
+    All samples are validated with stdlib `re` (the grammar rstr builds on),
+    even when `rule.compiled` is an RE2 pattern. Patterns that are both
+    fully-anchored (`^...$`, `\\A...\\Z`) AND have a small match language
+    (e.g. `^literal$`) can't be augmented past their intrinsic minimum —
+    padding breaks the anchors so re-validation rejects candidates — and
+    will raise `GenerationError` unless the caller opts into `skip_invalid`.
+    Fully-anchored patterns with large match spaces (e.g. `^[a-z]{5}$`)
+    reach `samples_per_rule` from stage 1 alone.
     """
 
     def __init__(
@@ -364,15 +382,86 @@ class CorpusGenerator:
         )
         return entries
 
+    # Corpus generation is a three-stage pipeline, each stage invoked only
+    # when the previous one didn't reach `samples_per_rule`:
+    #
+    #   1. `rstr.xeger`  — derivation-based sampling from the pattern's AST.
+    #                      Fast and precise for patterns with inherent
+    #                      variability (charclasses, quantifiers, alternation).
+    #                      For literal-heavy patterns it produces the same 1-5
+    #                      strings repeatedly, since the match language itself
+    #                      is small. Can also throw on features its parser
+    #                      doesn't model (some escape/quantifier combinations).
+    #
+    #   2. Mutational augmentation — for every base match stage 1 produced,
+    #                      wrap it in random context and re-validate. This
+    #                      is the standard corpus-fuzzing move (AFL/libFuzzer
+    #                      style): real-world strings matching a pattern
+    #                      contain the match embedded in surrounding text, so
+    #                      padding + re-validation generates realistic corpora
+    #                      for literal-heavy but unanchored rules. When stage
+    #                      1 already produced a diverse set (the pattern has
+    #                      plenty of inherent variability), this stage is a
+    #                      no-op. When the pattern is both fully-anchored and
+    #                      narrow, padding breaks the anchor and candidates
+    #                      fail re-validation — the set stays minimal and the
+    #                      caller gets a GenerationError.
+    #
+    #   3. Random fallback — for patterns rstr couldn't parse at all and
+    #                      that aren't anchored. Blind random ASCII; only
+    #                      productive when the pattern is broad enough that
+    #                      random strings happen to match.
+    _RSTR_ATTEMPT_MULTIPLIER = 3
+    _PAD_ATTEMPT_MULTIPLIER = 20
+    _PAD_MAX_SIDE_LENGTH = 24
+    _PAD_CHARSET = string.ascii_letters + string.digits + string.punctuation + " "
+
     def _generate_positive(self, rule: Rule, validator: re.Pattern[str]) -> list[str]:
-        """Generate matching strings for a rule using rstr with fallback."""
-        # Attempt count: generate more than needed to account for validation failures
-        attempt_count = self.samples_per_rule * 3
+        """Generate matching strings for a rule via rstr → padding → fallback."""
         strings: set[str] = set()
         deadline = time.monotonic() + self.generation_timeout_s
 
-        # Strategy 1: rstr.xeger
-        rstr_ok = True
+        rstr_attempts, rstr_matches = self._sample_via_rstr(rule, validator, strings, deadline)
+
+        if len(strings) < self.samples_per_rule and strings:
+            # Stage 2: mutational augmentation. Productive whenever rstr
+            # produced any base matches — padding an anchored pattern just
+            # won't produce new samples, the loop exits at its attempt cap.
+            self._augment_with_padding(strings, validator, deadline)
+
+        if len(strings) < self.min_valid_samples and rstr_attempts == 0:
+            # Stage 3: rstr couldn't parse the pattern at all and stage 2
+            # had nothing to augment. Random ASCII is a coarse last resort.
+            log.info(
+                "Rule '%s': rstr.xeger failed on all attempts, using random fallback",
+                rule.name,
+            )
+            self._fallback_generate(rule, strings, deadline, validator)
+
+        if rstr_attempts:
+            match_rate = rstr_matches / rstr_attempts
+            log.debug(
+                "Rule '%s': rstr match rate %.0f%% (%d/%d), final corpus %d",
+                rule.name,
+                match_rate * 100,
+                rstr_matches,
+                rstr_attempts,
+                len(strings),
+            )
+
+        return list(strings)
+
+    def _sample_via_rstr(
+        self,
+        rule: Rule,
+        validator: re.Pattern[str],
+        strings: set[str],
+        deadline: float,
+    ) -> tuple[int, int]:
+        """Stage 1: derivation-based sampling. Returns (non-raising attempts, matches)."""
+        attempt_count = self.samples_per_rule * self._RSTR_ATTEMPT_MULTIPLIER
+        attempts = 0
+        matches = 0
         for _ in range(attempt_count):
             if time.monotonic() > deadline:
                 break
@@ -380,22 +469,41 @@ class CorpusGenerator:
                 break
             try:
                 s = rstr.xeger(rule.pattern)
-                if len(s) <= self.max_string_length and validator.search(s):
-                    strings.add(s)
             except Exception:
-                rstr_ok = False
+                # Some patterns make rstr throw intermittently (complex
+                # character classes, unusual escapes). Keep trying — a
+                # pattern may fail 40% of calls and succeed on 60%, still
+                # giving plenty of useful output.
+                continue
+            attempts += 1
+            if len(s) <= self.max_string_length and validator.search(s):
+                matches += 1
+                strings.add(s)
+        return attempts, matches
+
+    def _augment_with_padding(
+        self,
+        strings: set[str],
+        validator: re.Pattern[str],
+        deadline: float,
+    ) -> None:
+        """Stage 2: mutational augmentation — pad each base match with random
+        context and keep the re-validated variants."""
+        bases = list(strings)
+        attempt_budget = self.samples_per_rule * self._PAD_ATTEMPT_MULTIPLIER
+        for _ in range(attempt_budget):
+            if time.monotonic() > deadline:
                 break
-
-        if not rstr_ok or len(strings) < self.min_valid_samples:
-            if not rstr_ok:
-                log.info(
-                    "Rule '%s': rstr.xeger failed, using fallback generator",
-                    rule.name,
-                )
-            # Strategy 2: fallback generator
-            self._fallback_generate(rule, strings, deadline, validator)
-
-        return list(strings)
+            if len(strings) >= self.samples_per_rule:
+                break
+            base = random.choice(bases)
+            prefix_len = random.randint(0, self._PAD_MAX_SIDE_LENGTH)
+            suffix_len = random.randint(0, self._PAD_MAX_SIDE_LENGTH)
+            prefix = "".join(random.choices(self._PAD_CHARSET, k=prefix_len))
+            suffix = "".join(random.choices(self._PAD_CHARSET, k=suffix_len))
+            candidate = prefix + base + suffix
+            if len(candidate) <= self.max_string_length and validator.search(candidate):
+                strings.add(candidate)
 
     def _fallback_generate(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["crossfire*"]
 
 [project]
 name = "crossfire-rules"
-version = "0.2.5"
+version = "0.2.6"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -106,31 +106,219 @@ class TestMultipleRules:
             assert len(positive) >= 10
 
 
+# A pattern where rstr.xeger reliably raises (ValueError: empty range in
+# randint) — the quantifier on the second `[a-f0-9]` range creates a length
+# rstr's sampler can't satisfy. Used by tests that need "genuinely
+# unsynthesizable" behavior. Same shape as the real `cloudflare_origin_ca_key`
+# gitleaks rule that motivated this test strategy.
+_UNSYNTHESIZABLE_PATTERN = r"\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\x60'\"\s;]|\\[nr]|$)"
+
+
 class TestFailFast:
     def test_generation_failure_raises(self):
+        """When rstr can't synthesize and the fallback can't match either,
+        generation fails with GenerationError."""
         gen = CorpusGenerator(
-            samples_per_rule=50,
-            min_valid_samples=50,  # impossible for simple pattern
+            samples_per_rule=20,
+            min_valid_samples=10,
             negative_samples=0,
             generation_timeout_s=0.5,
             seed=42,
         )
-        # Pattern that generates only 1 unique string
-        rule = _make_rule("single", r"^exact_match_only$")
+        rule = _make_rule("unsynth", _UNSYNTHESIZABLE_PATTERN)
         with pytest.raises(GenerationError, match=r"only .* valid samples"):
             gen.generate([rule])
 
     def test_generation_failure_skip(self):
+        """skip_invalid=True turns the generation failure into a silent drop."""
         gen = CorpusGenerator(
-            samples_per_rule=50,
-            min_valid_samples=50,
+            samples_per_rule=20,
+            min_valid_samples=10,
             negative_samples=0,
             generation_timeout_s=0.5,
             seed=42,
         )
-        rule = _make_rule("single", r"^exact_match_only$")
+        rule = _make_rule("unsynth", _UNSYNTHESIZABLE_PATTERN)
         entries = gen.generate([rule], skip_invalid=True)
         assert len(entries) == 0
+
+
+class TestMutationalAugmentation:
+    """Stage 2 of the corpus pipeline: pad minimal rstr matches with random
+    context and re-validate. Real corpora contain the pattern embedded in
+    surrounding text (mutational fuzzing style), so a literal-heavy but
+    unanchored rule should still produce the full `samples_per_rule`.
+
+    Motivated by lumen-argus community.json rules (`ssh_private_key`,
+    `private_key_pem`, `inst_tag`) producing only 1-5 samples on 0.2.5
+    because rstr deduplicated to the minimal match language.
+    """
+
+    def test_unanchored_literal_gets_full_sample_count_via_padding(self):
+        """A literal pattern with no anchors should produce samples_per_rule
+        variants by padding the base match with random context."""
+        gen = CorpusGenerator(
+            samples_per_rule=30,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        base = "-----BEGIN OPENSSH PRIVATE KEY-----"
+        rule = _make_rule("literal", base)
+        entries = gen.generate([rule])
+        positives = [e for e in entries if not e.is_negative]
+        assert len(positives) == 30, f"expected 30 padded variants, got {len(positives)}"
+        # Every sample contains the literal and still validates.
+        for e in positives:
+            assert base in e.text
+            assert rule.compiled.search(e.text)
+        # And meaningful diversity — at least half should be unique padded forms.
+        assert len({e.text for e in positives}) >= 15
+
+    def test_short_alternation_expands_via_padding(self):
+        """A 5-alternative pattern produces 5 base matches; padding expands
+        each into many context-varied samples."""
+        gen = CorpusGenerator(
+            samples_per_rule=30,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        pattern = r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+        rule = _make_rule("alt", pattern)
+        entries = gen.generate([rule])
+        positives = [e for e in entries if not e.is_negative]
+        assert len(positives) == 30
+        for e in positives:
+            assert re.search(pattern, e.text)
+
+    def test_case_insensitive_literal_expands_via_padding(self):
+        """`(?i)\\[INST\\]` — padding introduces variety even though the
+        pattern's core match language is just case permutations of [INST]."""
+        gen = CorpusGenerator(
+            samples_per_rule=30,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        rule = _make_rule("inst", r"(?i)\[INST\]")
+        entries = gen.generate([rule])
+        positives = [e for e in entries if not e.is_negative]
+        assert len(positives) == 30
+        for e in positives:
+            assert re.search(r"(?i)\[INST\]", e.text)
+
+    def test_fully_anchored_pattern_stays_at_minimal_set(self):
+        """`^literal$` cannot be padded — padding would push the match past
+        the anchors and re-validation would fail. The generator legitimately
+        yields only the single possible match; with `min_valid_samples=10`
+        above that, generation fails hard, and that's correct behavior."""
+        gen = CorpusGenerator(
+            samples_per_rule=30,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        rule = _make_rule("anchored", r"^exact-anchored-literal$")
+        with pytest.raises(GenerationError, match=r"only 1 valid samples"):
+            gen.generate([rule])
+
+    def test_fully_anchored_narrow_skipped_with_skip_invalid(self):
+        """Same rule, but skip_invalid=True turns the GenerationError into a
+        silent drop — the downstream analysis keeps going on the remaining
+        rules."""
+        gen = CorpusGenerator(
+            samples_per_rule=30,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        rule = _make_rule("anchored", r"^exact-anchored-literal$")
+        entries = gen.generate([rule], skip_invalid=True)
+        assert entries == []
+
+    def test_padded_samples_feed_downstream_overlap_detection(self):
+        """A narrow rule's padded samples should still enable overlap
+        detection — the padded strings are valid matches of the rule, so
+        any broader rule that also matches them will be picked up."""
+        gen = CorpusGenerator(
+            samples_per_rule=20,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        narrow = _make_rule("narrow", r"unique-marker-xyz-123")
+        broad = _make_rule("broad_contains_marker", r"unique-marker-\w+")
+        entries = gen.generate([narrow, broad])
+        narrow_samples = [e.text for e in entries if e.source_rule == "narrow"]
+        assert len(narrow_samples) == 20
+        # Every narrow sample must also be matched by the broader rule —
+        # that's how overlap analysis would detect the relationship.
+        for text in narrow_samples:
+            assert broad.compiled.search(text)
+
+
+class TestIntermittentRstrFailures:
+    """Some patterns make rstr throw on a fraction of calls — the generator
+    must not `break` on the first exception, or we lose the useful output
+    from the calls that would have succeeded.
+
+    Motivated by the `atlassian_api_token` rule (42/90 rstr exceptions,
+    but 48/90 successful matches when we kept trying).
+    """
+
+    def test_exception_on_some_attempts_does_not_stop_generation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulate rstr raising every other call; generator must keep going."""
+        import rstr as rstr_mod
+
+        call_count = {"n": 0}
+        real_xeger = rstr_mod.xeger
+
+        def flaky_xeger(pattern: str) -> str:
+            call_count["n"] += 1
+            if call_count["n"] % 2 == 0:
+                raise ValueError("simulated intermittent rstr failure")
+            return real_xeger(pattern)
+
+        monkeypatch.setattr(rstr_mod, "xeger", flaky_xeger)
+
+        gen = CorpusGenerator(
+            samples_per_rule=20,
+            min_valid_samples=10,
+            negative_samples=0,
+            seed=42,
+        )
+        rule = _make_rule("flaky", r"[a-z]{10}")
+        entries = gen.generate([rule])
+        positives = [e for e in entries if not e.is_negative]
+        # With half of attempts raising, we should still get plenty of samples.
+        assert len(positives) >= 10
+
+    def test_all_exceptions_falls_back_to_random_generation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When rstr raises every time, the fallback generator must kick in
+        and (for patterns that random ASCII can match) produce samples."""
+        import rstr as rstr_mod
+
+        def always_raise(pattern: str) -> str:
+            raise ValueError("simulated total rstr failure")
+
+        monkeypatch.setattr(rstr_mod, "xeger", always_raise)
+
+        gen = CorpusGenerator(
+            samples_per_rule=20,
+            min_valid_samples=5,
+            negative_samples=0,
+            seed=42,
+        )
+        # Random ASCII can match `[a-z]+` easily.
+        rule = _make_rule("random_matchable", r"[a-z]+")
+        entries = gen.generate([rule])
+        positives = [e for e in entries if not e.is_negative]
+        assert len(positives) >= 5
 
 
 class TestReproducibility:
@@ -189,15 +377,15 @@ class TestParallelGeneration:
     def test_parallel_skip_invalid(self):
         """Parallel path should respect skip_invalid."""
         gen = CorpusGenerator(
-            samples_per_rule=50,
-            min_valid_samples=50,
+            samples_per_rule=20,
+            min_valid_samples=10,
             negative_samples=0,
             generation_timeout_s=0.5,
             seed=42,
         )
-        # Mix valid and impossible rules to exceed threshold of 8
+        # Mix valid rules and one genuinely unsynthesizable rule to exceed threshold of 8
         rules = [_make_rule(f"ok_{i}", rf"[a-z]{{{i + 3}}}") for i in range(8)]
-        rules.append(_make_rule("impossible", r"^exact_single_match$"))
+        rules.append(_make_rule("impossible", _UNSYNTHESIZABLE_PATTERN))
         entries = gen.generate(rules, skip_invalid=True)
         sources = {e.source_rule for e in entries}
         assert "impossible" not in sources


### PR DESCRIPTION
## Summary

Fixes the remaining corpus-generation regressions reported by the lumen-argus team after 0.2.5 — 4 of the 6 regressing `community.json` rules now generate 30/30 samples instead of 0.

Root cause was two separate bugs:

1. **rstr.xeger loop aborted on first exception.** Patterns like `atlassian_api_token` throw on ~42/90 calls but succeed on the remaining 48. The old code `break`d on first throw, producing zero samples.
2. **Narrow-match-language rules saturated at 1-5 samples.** rstr.xeger produces minimal matches; for a literal pattern like `ssh_private_key`, the match language has exactly one member, so dedup capped the set at 1. The `min_valid_samples=10` threshold then fired as a hard error.

## Changes

- **`crossfire/generator.py`** — corpus pipeline is now 3-stage:
  1. `rstr.xeger` — derivation-based minimal matches (unchanged, but now `continue`s past exceptions)
  2. **Mutational augmentation (new)** — pad each base match with random context and re-validate (AFL/libFuzzer style). Fills `samples_per_rule` for unanchored literal-heavy rules. Anchored-and-narrow patterns still fail because padding breaks the anchors.
  3. Random-ASCII fallback — only when rstr can't parse the pattern at all (unchanged)
- **`tests/test_generator.py`** — new `TestMutationalAugmentation` (6 tests) and `TestIntermittentRstrFailures` (2 tests). Existing `TestFailFast` and `TestParallelGeneration::test_parallel_skip_invalid` retargeted to use a genuinely-unsynthesizable pattern (`cloudflare_origin_ca_key` shape) instead of the old literal.
- **`.pre-commit-config.yaml`** — scope `detect-private-key` hook to skip `CHANGELOG.md` and `tests/test_generator.py` (PEM key-header markers appear as regex-pattern fixtures, not real keys).
- **`pyproject.toml`** — 0.2.6
- **`CHANGELOG.md`** — new `[0.2.6]` section with "Added" (augmentation) and "Fixed" (rstr loop + narrow-match handling).

## Impact on downstream community.json (90 rules)

| Rule | 0.2.5 | 0.2.6 |
|---|---|---|
| `ssh_private_key` | 0 | 30 |
| `private_key_pem` | 0 | 30 |
| `inst_tag` | 0 | 30 |
| `atlassian_api_token` | 0 | 30 |
| `cloudflare_origin_ca_key` | 0 | 0 (rstr can't parse `{146}`; skipped under `skip_invalid=True`) |
| `kubernetes_secret_yaml` | 0 | 0 (wildcards + anchors exceed random padding; skipped under `skip_invalid=True`) |

## Test plan

- [x] `pytest` — 264 passed (up from 256, adds 8 augmentation/exception tests)
- [x] `ruff check`, `ruff format --check`, `mypy crossfire/` clean
- [x] End-to-end verified against `/Users/slim/dev/lumen-argus/packages/proxy/lumen_argus/rules/community.json` — 2640 total positive entries across 88/90 rules

## Breaking changes

None for public API. Behavioral: rules that previously raised `GenerationError` due to small match languages now succeed. Callers that relied on those failures (unlikely, but possible) should add explicit rule-quality checks or filter via `metadata`.

## Release note

After merge, tag `v0.2.6` and push to trigger PyPI.