### PR TITLE
Release 0.2.9: diversity warning + CI lint matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,18 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      # Run lint on every supported interpreter. mypy's output depends on the
+      # running interpreter's stubs and stdlib, so a "fine on 3.12" result is
+      # no guarantee on 3.13/3.14. Catches drift (stale `type: ignore`s,
+      # checks that newly fire or newly pass) before it bites locally.
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Lint
@@ -27,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Crossfire will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] - 2026-04-22
+
+### Added
+
+- **Sample diversity warning.** The generator already raises on *count* failures (fewer than `min_valid_samples` survived) but was silent when rstr produced many copies of a single degenerate shape — the exact failure mode behind the 0.2.7 `kubernetes_secret_yaml` report (27 samples / ~10 unique middles, all sharing one core). `CorpusGenerator.generate` now runs a parent-side pass after corpus collection: for each rule, it computes the number of unique middle-50-char slices across the positive samples and logs a WARNING when the ratio falls below `0.4` (minimum 10 samples, otherwise the ratio is noise). Middle slices specifically — stage-2 padding fans random bytes onto both ends of every base match, so prefix/suffix-based uniqueness looks high even when every sample derives from a single degenerate base. Runs parent-side so warnings fire under both sequential and parallel backends (spawn workers don't forward logs). Callers who only want the metric (not the warning) can filter the `crossfire.generator` logger at their end. On the lumen-argus 90-rule community corpus, 0.2.9 fires zero diversity warnings — 0.2.8's non-greedy fix already landed the real behavior fix; this pass is the caller-visible surface so future silent regressions get caught immediately. Threshold chosen empirically: catches the pre-0.2.8 `kubernetes_secret_yaml` regression (0.37) while leaving inherently narrow patterns like `inst_tag` (16/30 = 0.53) above the line. Regression coverage: `tests/test_generator.py::TestDiversityMetric`.
+
+### Changed
+
+- **CI lint now runs under every supported Python version.** The lint job was pinned to 3.12; mypy's output depends on the running interpreter's stubs and stdlib, so a "fine on 3.12" result was no guarantee on 3.13 or 3.14 — stale `# type: ignore` pragmas would silently pass CI and surface only when a contributor upgraded Python locally (which is what happened on 0.2.8 with the rstr `_handle_state` method-assign check). The `lint` job now runs the same Ruff + mypy strict pass under matrix `["3.12", "3.13", "3.14"]`. Test matrix also extended to 3.14. Pyproject classifiers updated to declare 3.14 support — local has been clean on 3.14 for several releases, just hadn't been formally declared.
+
 ## [0.2.8] - 2026-04-21
 
 ### Fixed

--- a/crossfire/generator.py
+++ b/crossfire/generator.py
@@ -90,6 +90,29 @@ def _patched_handle_state(self: Any, state: Any) -> Any:
 setattr(_RstrXeger, "_handle_repeat", _patched_handle_repeat)  # noqa: B010
 setattr(_RstrXeger, "_handle_state", _patched_handle_state)  # noqa: B010
 
+
+def _diversity_ratio(samples: list[str], middle_chars: int) -> tuple[float, int]:
+    """Return (unique_middles / len(samples), unique_middles).
+
+    Middle-N slice: center `middle_chars` characters of each sample, or the
+    whole sample when shorter. Stage-2 padding wraps every base match with
+    random prefix/suffix bytes, so prefix/suffix-based uniqueness looks high
+    even when every sample derives from a single degenerate base. The middle
+    preserves the shape the regex actually matched against.
+    """
+    if not samples:
+        return 1.0, 0
+    middles: set[str] = set()
+    for s in samples:
+        length = len(s)
+        if length <= middle_chars:
+            middles.add(s)
+        else:
+            start = (length - middle_chars) // 2
+            middles.add(s[start : start + middle_chars])
+    return len(middles) / len(samples), len(middles)
+
+
 # We default to "spawn" rather than "fork" because forking from a multi-threaded
 # parent process is unsafe: child processes inherit memory but only the calling
 # thread, leaving any locks held by other parent threads permanently locked in
@@ -286,6 +309,8 @@ class CorpusGenerator:
         else:
             log.info("Corpus generation: sequential mode (%d rules)", len(rules))
             all_entries, skipped = self._generate_sequential(rules, skip_invalid=skip_invalid)
+
+        self._warn_on_low_diversity(all_entries)
 
         duration = time.monotonic() - t0
         log.info(
@@ -488,6 +513,17 @@ class CorpusGenerator:
     _PAD_MAX_SIDE_LENGTH = 24
     _PAD_CHARSET = string.ascii_letters + string.digits + string.punctuation + " "
 
+    # Diversity metric: number of unique middle-N-char slices over total samples.
+    # Middles (not prefixes/suffixes) because stage-2 padding fans random bytes
+    # onto both ends of every base match, so prefix/suffix diversity is inflated
+    # and hides whether the underlying rstr pass produced a genuinely varied set.
+    # Threshold of 0.4 catches the 0.2.7 `kubernetes_secret_yaml` regression
+    # (10 unique / 27 samples = 0.37) while leaving inherently narrow patterns
+    # like `inst_tag` (16/30 = 0.53) above the line.
+    _DIVERSITY_MIDDLE_CHARS = 50
+    _DIVERSITY_WARN_THRESHOLD = 0.4
+    _DIVERSITY_MIN_SAMPLES = 10
+
     def _generate_positive(self, rule: Rule, validator: re.Pattern[str]) -> list[str]:
         """Generate matching strings for a rule via rstr → padding → fallback."""
         strings: set[str] = set()
@@ -601,6 +637,47 @@ class CorpusGenerator:
                 s = "".join(random.choices(charset, k=length))
                 if len(s) <= self.max_string_length and validator.search(s):
                     strings.add(s)
+
+    def _warn_on_low_diversity(self, entries: list[CorpusEntry]) -> None:
+        """Inspect generated positive samples per-rule and warn on degeneracy.
+
+        Runs parent-side after collection so warnings fire regardless of
+        parallel/sequential mode (spawn workers don't forward logs). Silent-
+        degenerate output is the failure mode rstr's non-greedy bug hit on
+        `kubernetes_secret_yaml` (27 samples / ~10 unique middles, all sharing
+        the same degenerate core). The generator itself raises only on *count*
+        failures; this pass makes *shape* failures observable without changing
+        control flow.
+        """
+        per_rule: dict[str, list[str]] = {}
+        for e in entries:
+            if e.is_negative:
+                continue
+            per_rule.setdefault(e.source_rule, []).append(e.text)
+
+        for rule_name, samples in per_rule.items():
+            if len(samples) < self._DIVERSITY_MIN_SAMPLES:
+                continue
+            ratio, unique = _diversity_ratio(samples, self._DIVERSITY_MIDDLE_CHARS)
+            if ratio < self._DIVERSITY_WARN_THRESHOLD:
+                log.warning(
+                    "Rule '%s': low sample diversity (%d unique middle-%d-char "
+                    "slices across %d samples, ratio %.2f). Samples likely share "
+                    "a single degenerate shape — corpus value is limited.",
+                    rule_name,
+                    unique,
+                    self._DIVERSITY_MIDDLE_CHARS,
+                    len(samples),
+                    ratio,
+                )
+            else:
+                log.debug(
+                    "Rule '%s': sample diversity %d/%d (ratio %.2f)",
+                    rule_name,
+                    unique,
+                    len(samples),
+                    ratio,
+                )
 
     def _generate_negative(
         self, rule: Rule, positive: list[str], validator: re.Pattern[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["crossfire*"]
 
 [project]
 name = "crossfire-rules"
-version = "0.2.8"
+version = "0.2.9"
 description = "Regex rule overlap analyzer for DLP, secret scanning, SAST, and IDS tools"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -425,6 +425,153 @@ class TestNonGreedyRepeat:
         )
 
 
+class TestDiversityMetric:
+    """The generator raises on *count* failures (fewer than `min_valid_samples`
+    survived) but is otherwise silent when rstr produces many copies of a
+    single degenerate shape — the `kubernetes_secret_yaml` 0.2.7 failure mode.
+    `_warn_on_low_diversity` runs parent-side after corpus collection and
+    surfaces shape failures as WARNING without changing control flow.
+    """
+
+    def test_low_diversity_emits_warning(self, caplog):
+        """Synthetic corpus of identical middles must trigger the warning."""
+        from crossfire.generator import _diversity_ratio
+        from crossfire.models import CorpusEntry
+
+        gen = CorpusGenerator(samples_per_rule=30, min_valid_samples=10)
+
+        base = "X" * 80
+        entries = [
+            CorpusEntry(text=f"prefix{i}_{base}_suffix{i}", source_rule="degen", is_negative=False)
+            for i in range(20)
+        ]
+        ratio, unique = _diversity_ratio([e.text for e in entries], 50)
+        assert unique == 1
+        assert ratio < 0.1
+
+        with caplog.at_level("WARNING", logger="crossfire.generator"):
+            gen._warn_on_low_diversity(entries)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("low sample diversity" in r.getMessage() for r in warnings)
+        assert any("'degen'" in r.getMessage() for r in warnings)
+
+    def test_high_diversity_stays_quiet(self, caplog):
+        """Distinct middles must not fire the warning."""
+        from crossfire.models import CorpusEntry
+
+        gen = CorpusGenerator(samples_per_rule=30, min_valid_samples=10)
+        entries = [
+            CorpusEntry(
+                text=f"{'X' * 30}_unique_content_{i:04d}_{'Y' * 30}",
+                source_rule="diverse",
+                is_negative=False,
+            )
+            for i in range(20)
+        ]
+
+        with caplog.at_level("WARNING", logger="crossfire.generator"):
+            gen._warn_on_low_diversity(entries)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("low sample diversity" in r.getMessage() for r in warnings)
+
+    def test_small_sample_set_skips_check(self, caplog):
+        """Below _DIVERSITY_MIN_SAMPLES the ratio isn't meaningful — skip."""
+        from crossfire.models import CorpusEntry
+
+        gen = CorpusGenerator(samples_per_rule=30, min_valid_samples=10)
+        entries = [
+            CorpusEntry(text="same_middle_exactly", source_rule="tiny", is_negative=False)
+            for _ in range(5)
+        ]
+
+        with caplog.at_level("WARNING", logger="crossfire.generator"):
+            gen._warn_on_low_diversity(entries)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("low sample diversity" in r.getMessage() for r in warnings)
+
+    def test_negative_samples_ignored(self, caplog):
+        """Diversity is about positive corpus quality; negatives aren't counted."""
+        from crossfire.models import CorpusEntry
+
+        gen = CorpusGenerator(samples_per_rule=30, min_valid_samples=10)
+        # Many identical negatives + one positive — must not fire (positives below min).
+        entries = [
+            CorpusEntry(text="identical_neg", source_rule="r", is_negative=True) for _ in range(50)
+        ]
+        entries.append(CorpusEntry(text="lone_positive", source_rule="r", is_negative=False))
+
+        with caplog.at_level("WARNING", logger="crossfire.generator"):
+            gen._warn_on_low_diversity(entries)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("low sample diversity" in r.getMessage() for r in warnings)
+
+    def test_per_rule_independent(self, caplog):
+        """Each rule's diversity is computed independently."""
+        from crossfire.models import CorpusEntry
+
+        gen = CorpusGenerator(samples_per_rule=30, min_valid_samples=10)
+        entries = []
+        # Rule A: degenerate (all identical middles)
+        entries.extend(
+            CorpusEntry(text=f"p{i}_" + "Z" * 80 + f"_s{i}", source_rule="ruleA", is_negative=False)
+            for i in range(15)
+        )
+        # Rule B: diverse (unique middles)
+        entries.extend(
+            CorpusEntry(
+                text=f"{'X' * 30}_unique_{i:04d}_{'Y' * 30}",
+                source_rule="ruleB",
+                is_negative=False,
+            )
+            for i in range(15)
+        )
+
+        with caplog.at_level("WARNING", logger="crossfire.generator"):
+            gen._warn_on_low_diversity(entries)
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("'ruleA'" in w and "low sample diversity" in w for w in warnings)
+        assert not any("'ruleB'" in w and "low sample diversity" in w for w in warnings)
+
+    def test_generate_invokes_diversity_check(self, monkeypatch):
+        """Wiring check: generate() must call _warn_on_low_diversity on the
+        collected corpus. Runs parent-side so the warning fires regardless of
+        parallel/sequential backend (spawn workers don't forward logs).
+        """
+        rule = _make_rule("a", r"[a-z]{5,10}")
+        gen = CorpusGenerator(samples_per_rule=10, min_valid_samples=5, negative_samples=0)
+
+        seen: list[list] = []
+        monkeypatch.setattr(
+            type(gen), "_warn_on_low_diversity", lambda self, entries: seen.append(entries)
+        )
+
+        entries = gen.generate([rule], parallel=False)
+        assert len(seen) == 1
+        assert seen[0] == entries
+
+    def test_diversity_ratio_short_samples(self):
+        """Samples shorter than middle_chars use the whole string as the key."""
+        from crossfire.generator import _diversity_ratio
+
+        samples = ["abc", "abc", "def", "ghi"]
+        ratio, unique = _diversity_ratio(samples, 50)
+        assert unique == 3
+        assert ratio == 0.75
+
+    def test_diversity_ratio_empty(self):
+        """Empty input doesn't divide by zero."""
+        from crossfire.generator import _diversity_ratio
+
+        ratio, unique = _diversity_ratio([], 50)
+        assert ratio == 1.0
+        assert unique == 0
+
+
 class TestIntermittentRstrFailures:
     """Some patterns make rstr throw on a fraction of calls — the generator
     must not `break` on the first exception, or we lose the useful output


### PR DESCRIPTION
## Summary

- **Sample diversity warning** — parent-side pass after corpus collection flags rules whose samples collapse onto a single degenerate shape (the silent-failure mode that 0.2.8 fixed the root cause for). Middle-50-char unique ratio; warns when `< 0.4` and samples `>= 10`.
- **CI lint matrix** — Ruff + mypy now run under Python 3.12, 3.13, 3.14 (previously 3.12 only). Catches mypy drift that bit the 0.2.8 release. Test matrix also extended to 3.14. Pyproject classifiers add 3.14.

Follow-ups from the lumen-argus 0.2.8 artifact review — two follow-ups evaluated but deferred as non-bugs: rstr `.` char pool (rstr is correct, `.` legitimately matches any char) and rstr overgeneration waste (71% waste on pathological k8s pattern costs ~60ms per rule — not worth invasive rstr surgery).

## Test plan

- [x] `pytest` → 280 passed under py3.14 local
- [x] `ruff check` clean
- [x] `mypy --strict crossfire/` clean
- [x] Smoke on 89-rule lumen-argus community.json → 0 diversity warnings (0.2.8 fix holds)
- [ ] CI lint across 3.12/3.13/3.14
- [ ] CI tests across 3.12/3.13/3.14